### PR TITLE
Add User/Household/HouseholdMember models, migration, and seed

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -10,7 +10,11 @@
     "db:migrate": "prisma migrate dev",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",
-    "db:generate": "prisma generate"
+    "db:generate": "prisma generate",
+    "db:seed": "tsx prisma/seed.ts"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
   },
   "keywords": [],
   "author": "",
@@ -23,11 +27,13 @@
     "@fastify/swagger-ui": "^5.2.6",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
+    "bcryptjs": "^3.0.3",
     "dotenv": "^17.4.2",
     "fastify": "^5.8.5",
     "pg": "^8.20.0"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^3.0.0",
     "@types/pg": "^8.20.0",
     "@types/supertest": "^7.2.0",
     "@vitest/coverage-v8": "^4.1.5",

--- a/api/prisma/migrations/20260430000000_auth_tenancy/migration.sql
+++ b/api/prisma/migrations/20260430000000_auth_tenancy/migration.sql
@@ -1,0 +1,45 @@
+-- CreateEnum
+CREATE TYPE "MemberRole" AS ENUM ('OWNER', 'MEMBER');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN "email" TEXT NOT NULL DEFAULT '',
+ADD COLUMN "passwordHash" TEXT NOT NULL DEFAULT '',
+ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable — remove temporary defaults
+ALTER TABLE "User" ALTER COLUMN "email" DROP DEFAULT,
+ALTER COLUMN "passwordHash" DROP DEFAULT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateTable
+CREATE TABLE "Household" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Household_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "HouseholdMember" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "householdId" TEXT NOT NULL,
+    "role" "MemberRole" NOT NULL,
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "HouseholdMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "HouseholdMember_userId_householdId_key" ON "HouseholdMember"("userId", "householdId");
+
+-- AddForeignKey
+ALTER TABLE "HouseholdMember" ADD CONSTRAINT "HouseholdMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "HouseholdMember" ADD CONSTRAINT "HouseholdMember_householdId_fkey" FOREIGN KEY ("householdId") REFERENCES "Household"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -15,6 +15,39 @@ datasource db {
 //   Phase 4 — Reminder
 //   Phase 5 — NotificationChannel
 
+enum MemberRole {
+  OWNER
+  MEMBER
+}
+
 model User {
-  id String @id @default(cuid())
+  id           String   @id @default(cuid())
+  email        String   @unique
+  passwordHash String
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  memberships HouseholdMember[]
+}
+
+model Household {
+  id        String   @id @default(cuid())
+  name      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  members HouseholdMember[]
+}
+
+model HouseholdMember {
+  id          String     @id @default(cuid())
+  userId      String
+  householdId String
+  role        MemberRole
+  joinedAt    DateTime   @default(now())
+
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  household Household @relation(fields: [householdId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, householdId])
 }

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,0 +1,43 @@
+import {config} from 'dotenv';
+import {resolve, dirname} from 'path';
+import {fileURLToPath} from 'url';
+import {Pool} from 'pg';
+import {PrismaPg} from '@prisma/adapter-pg';
+import {PrismaClient} from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({path: resolve(__dirname, '../../.env.dev')});
+
+const pool = new Pool({connectionString: process.env.DATABASE_URL});
+const prisma = new PrismaClient({adapter: new PrismaPg(pool)});
+
+async function main() {
+  const passwordHash = await bcrypt.hash('password', 10);
+
+  const user = await prisma.user.upsert({
+    where: {email: 'test@example.com'},
+    update: {},
+    create: {
+      email: 'test@example.com',
+      passwordHash,
+      memberships: {
+        create: {
+          role: 'OWNER',
+          household: {
+            create: {name: 'Test Household'},
+          },
+        },
+      },
+    },
+  });
+
+  console.log(`Seeded user: ${user.email} (id: ${user.id})`);
+}
+
+main()
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -1,0 +1,8 @@
+import {Pool} from 'pg';
+import {PrismaPg} from '@prisma/adapter-pg';
+import {PrismaClient} from '@prisma/client';
+
+const pool = new Pool({connectionString: process.env.DATABASE_URL});
+const adapter = new PrismaPg(pool);
+
+export const prisma = new PrismaClient({adapter});

--- a/home-inventory-todo.md
+++ b/home-inventory-todo.md
@@ -39,7 +39,7 @@ End state: `docker compose up` gives you Postgres, Redis, and a Fastify server t
 - [x] Add structured logging (Pino is built in; set log levels per env)
 - [x] Configure Caddy to reverse-proxy `api.localhost` → `api:3000` with local TLS
 - [x] Scaffold Vitest + Supertest; write one smoke test against `/v1/health` — sets up the test harness before you write real business logic
-- [ ] Commit; verify `curl https://api.localhost/v1/health` works
+- [x] Commit; verify `curl https://api.localhost/v1/health` works
 
 ---
 
@@ -47,8 +47,8 @@ End state: `docker compose up` gives you Postgres, Redis, and a Fastify server t
 
 End state: users can register, log in, get a JWT, and every request is scoped to their household.
 
-- [ ] Prisma models: `User`, `Household`, `HouseholdMember` (with role enum)
-- [ ] Migration + seed script that creates a test user + household
+- [x] Prisma models: `User`, `Household`, `HouseholdMember` (with role enum)
+- [x] Migration + seed script that creates a test user + household
 - [ ] `POST /v1/auth/register` — creates user + default household in one transaction
 - [ ] `POST /v1/auth/login` — returns access + refresh token pair
 - [ ] `POST /v1/auth/refresh` — rotate on use: issue a new refresh token, invalidate the old one; a reused refresh token should invalidate the entire family (detect theft)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@prisma/client':
         specifier: ^7.8.0
         version: 7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
+      bcryptjs:
+        specifier: ^3.0.3
+        version: 3.0.3
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -54,6 +57,9 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
     devDependencies:
+      '@types/bcryptjs':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -675,6 +681,10 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/bcryptjs@3.0.0':
+    resolution: {integrity: sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==}
+    deprecated: This is a stub types definition. bcryptjs provides its own type definitions, so you do not need this installed.
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -887,6 +897,10 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bcryptjs@3.0.3:
+    resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
+    hasBin: true
 
   better-result@2.8.2:
     resolution: {integrity: sha512-YOf0VSj5nUPI27doTtXF+BBnsiRq3qY7avHqfIWnppxTLGyvkLq1QV2RTxkwoZwJ60ywLfZ0raFF4J/G886i7A==}
@@ -3026,6 +3040,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/bcryptjs@3.0.0':
+    dependencies:
+      bcryptjs: 3.0.3
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -3281,6 +3299,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bcryptjs@3.0.3: {}
 
   better-result@2.8.2: {}
 


### PR DESCRIPTION
- Adds MemberRole enum (OWNER, MEMBER) and three Prisma models with cascade deletes and a unique (userId, householdId) constraint
- Applies migration 20260430000000_auth_tenancy against the local DB
- Adds idempotent seed script (test@example.com / password as OWNER)
- Adds shared db.ts Prisma client using @prisma/adapter-pg
- Installs bcryptjs for password hashing